### PR TITLE
Added pg-tp-sqlite tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Tools by the community.
 - [TursoPy](https://github.com/MauriceKuenicke/tursopy): A fully type-hinted API wrapper for the Turso Platform, implemented in Python.
 - [turso-nim](https://codeberg.org/13thab/turso-nim): A Turso Platform API SDK for Nim 
 - [dbpu](https://github.com/conneroisu/dbpu): Full Golang Client for Turso Platform API, including databases.
+- [PostgreSQL to SQLite3 DB Conversion](https://github.com/hirefrank/pg-to-sqlite): A bash script that migrates data from a PostgreSQL database into a SQLite3 database file, that can then be upload to turso.
 
 
 <h2 id="templates-starters">Templates & Starters</h2>


### PR DESCRIPTION
This Bash script allows you to migrate data from a PostgreSQL database into a SQLite3 database file that can then be uploaded to turso.